### PR TITLE
Always close DIH EntityProcessor/DataSource

### DIFF
--- a/src/main/java/org/apache/solr/handler/dataimport/DataSource.java
+++ b/src/main/java/org/apache/solr/handler/dataimport/DataSource.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.handler.dataimport;
 
+import java.io.Closeable;
 import java.util.Properties;
 
 /**
@@ -35,7 +36,7 @@ import java.util.Properties;
  *
  * @since solr 1.3
  */
-public abstract class DataSource<T> {
+public abstract class DataSource<T> implements Closeable {
 
   /**
    * Initializes the DataSource with the <code>Context</code> and

--- a/src/main/java/org/apache/solr/handler/dataimport/DocBuilder.java
+++ b/src/main/java/org/apache/solr/handler/dataimport/DocBuilder.java
@@ -18,6 +18,7 @@ package org.apache.solr.handler.dataimport;
 
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.util.IOUtils;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.handler.dataimport.config.ConfigNameConstants;
 import org.apache.solr.handler.dataimport.config.DIHConfiguration;
@@ -269,24 +270,39 @@ public class DocBuilder {
     } catch(Exception e)
     {
       throw new RuntimeException(e);
-    } finally
-    {
-      if (writer != null) {
-        writer.close();
+    } finally {
+      // Cannot use IOUtils.closeQuietly since DIH relies on exceptions bubbling out of writer.close() to indicate
+      // success/failure of the run.
+      RuntimeException raisedDuringClose = null;
+      try {
+        if (writer != null) {
+          writer.close();
+        }
+      } catch (RuntimeException e) {
+        if (log.isWarnEnabled()) {
+          log.warn("Exception encountered while closing DIHWriter " + writer + "; temporarily suppressing to ensure other DocBuilder elements are closed", e); // logOk
+        }
+        raisedDuringClose = e;
       }
+
+
       if (epwList != null) {
         closeEntityProcessorWrappers(epwList);
       }
       if(reqParams.isDebug()) {
         reqParams.getDebugInfo().debugVerboseOutput = getDebugLogger().output;
       }
+
+      if (raisedDuringClose != null) {
+        throw raisedDuringClose;
+      }
     }
   }
   private void closeEntityProcessorWrappers(List<EntityProcessorWrapper> epwList) {
     for(EntityProcessorWrapper epw : epwList) {
-      epw.close();
+      IOUtils.closeQuietly(epw);
       if(epw.getDatasource()!=null) {
-        epw.getDatasource().close();
+        IOUtils.closeQuietly(epw.getDatasource());
       }
       closeEntityProcessorWrappers(epw.getChildren());
     }

--- a/src/main/java/org/apache/solr/handler/dataimport/EntityProcessor.java
+++ b/src/main/java/org/apache/solr/handler/dataimport/EntityProcessor.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.handler.dataimport;
 
+import java.io.Closeable;
 import java.util.Map;
 
 /**
@@ -36,7 +37,7 @@ import java.util.Map;
  *
  * @since solr 1.3
  */
-public abstract class EntityProcessor {
+public abstract class EntityProcessor implements Closeable {
 
   /**
    * This method is called when it starts processing an entity. When it comes


### PR DESCRIPTION
Prior to this commit, the wrapup logic at the end of
DocBuilder.execute() closed out a series of DIH objects, but did so
in a way that an exception closing any of them resulted in the remainder
staying open.  This is especially problematic since Writer.close()
throws exceptions that DIH uses to determine the success/failure of the
run.

In practice this caused network errors sending DIH data to other Solr
nodes to result in leaked JDBC connections.

This commit changes DocBuilder's termination logic to handle exceptions
more gracefully, ensuring that errors closing a DIHWriter (for example)
don't prevent the closure of entity-processor and DataSource objects.

See also, SOLR-14677